### PR TITLE
重构初始化逻辑：Binding 自动处理 doc 与 file 同步，移除手动 doc2xml 调用

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,24 @@ pnpm add y-mxgraph yjs y-protocols
 
 ```ts
 import * as Y from 'yjs';
-import { Binding, LOCAL_ORIGIN } from 'y-mxgraph';
+import { Binding } from 'y-mxgraph';
 
 const doc = new Y.Doc();
 
 App.main((app) => {
   const file = app.currentFile;
 
-  // If Y.Doc already has data (from other clients), use it
-  const mxfileMap = doc.getMap('mxfile');
-  const diagramMap = mxfileMap.get('diagram');
-  if (diagramMap && diagramMap.size > 0) {
-    const { doc2xml } = await import('y-mxgraph');
-    file.ui.setFileData(doc2xml(doc));
-    file.setData(doc2xml(doc));
-  } else if (!file.data) {
-    file.data = Binding.generateFileTemplate('diagram-0');
-  }
-
-  const binding = new Binding(file, { doc });
+  // Binding automatically reconciles file and Y.Doc based on
+  // `initialContent` strategy (default: 'replace').
+  //   - 'replace'      : Y.Doc wins; file UI is replaced with doc XML
+  //   - 'merge-remote' : union by diagram id; doc wins on conflicts
+  //   - 'merge-client' : union by diagram id; file wins on conflicts
+  //
+  // By default only `file.ui.setFileData(xml)` is called (rebuilds UI).
+  // `file.setData(xml)` is intentionally NOT called so draw.io does not
+  // mark the file as modified and pop up the "Save diagrams to:" dialog.
+  // Override via `applyFileData` if you need to sync `file.data` too.
+  const binding = new Binding(file, { doc /*, initialContent: 'merge-remote' */ });
 
   window.addEventListener('beforeunload', () => binding.destroy());
 });

--- a/apps/demo/src/collaboration.ts
+++ b/apps/demo/src/collaboration.ts
@@ -1,7 +1,7 @@
 import * as Y from "yjs";
 import { WebrtcProvider } from "y-webrtc";
 import { type Awareness } from "y-protocols/awareness";
-import { Binding, LOCAL_ORIGIN, doc2xml } from "y-mxgraph";
+import { Binding, LOCAL_ORIGIN } from "y-mxgraph";
 import { SIGNALING_SERVERS, DEFAULT_ROOM } from "./config.js";
 
 export interface CollabState {
@@ -65,37 +65,13 @@ export function bindDrawioFile(
   let isMounted = true;
 
   /**
-   * draw.io 的 file.patch() 只更新内部数据结构，不触发 UI 重新渲染。
-   * 因此需要在创建 Binding 前，手动把 Y.Doc 数据转成 XML 并设置到 file，
-   * 确保 draw.io 用正确的数据初始化。
-   *
-   * 这是当前 draw.io API 的限制，ws-demo 也采用相同方案。
+   * Binding 自身会按 `initialContent` 策略（默认 `replace`）调用
+   * `file.ui.setFileData` + `file.setData` 完成 UI 与数据对齐，
+   * 业务方无需再手动同步。
    */
   const doBind = (app: any, file: any) => {
     if (bindingCreated) return;
     bindingCreated = true;
-
-    const mxfileMap = doc.getMap("mxfile");
-    const diagramMap = mxfileMap.get("diagram") as any;
-    const docHasData = diagramMap && diagramMap.size > 0;
-
-    if (docHasData) {
-      const xml = doc2xml(doc);
-      if (xml && xml.includes("<diagram")) {
-        file.ui.setFileData(xml);
-        file.setData(xml);
-      } else {
-        const template = Binding.generateFileTemplate("diagram-0");
-        file.ui.setFileData(template);
-        file.setData(template);
-      }
-    } else {
-      if (!file.data) {
-        const template = Binding.generateFileTemplate("diagram-0");
-        file.ui.setFileData(template);
-        file.setData(template);
-      }
-    }
 
     const binding = new Binding(file, {
       doc,
@@ -153,7 +129,9 @@ export function bindDrawioFile(
 
   if (!provider) {
     setTimeout(tryBind, 800);
-    return () => { isMounted = false; };
+    return () => {
+      isMounted = false;
+    };
   }
 
   const mxfileKey = "mxfile";
@@ -191,7 +169,9 @@ export function bindDrawioFile(
     }
   }
 
-  return () => { isMounted = false; };
+  return () => {
+    isMounted = false;
+  };
 }
 
 export function disconnectCollaboration(state: CollabState): void {

--- a/apps/demo/src/drawio-loader.ts
+++ b/apps/demo/src/drawio-loader.ts
@@ -66,6 +66,7 @@ export function loadDrawioScript(
     (window as any).urlParams["math"] = "0";
     (window as any).urlParams["stealth"] = "1";
     (window as any).urlParams["chrome"] = "0";
+    (window as any).urlParams["demo"] = "1"; // 自动创建空白文件，跳过 "Save diagrams to:" 存储选择对话框
     if (lang) (window as any).urlParams["lang"] = lang;
 
     // 屏蔽 draw.io 内置的 window.onerror 弹窗（跨域脚本错误会触发 "Script error."）
@@ -137,6 +138,16 @@ export function loadDrawioScript(
 
       script.onload = () => {
         callbacks.onProgress("init");
+
+        // 覆写 draw.io 原型：禁用与 Yjs 实时持久化冲突的 native 对话框
+        const w = window as any;
+        if (w.App?.prototype) {
+          w.App.prototype.onBeforeUnload = function () {}; // 禁止 "All changes will be lost"
+        }
+        if (w.DrawioFile?.prototype) {
+          w.DrawioFile.prototype.addUnsavedStatus = function () {}; // 禁止 "Unsaved changes" 提示
+        }
+
         setTimeout(() => {
           callbacks.onReady(version);
           resolve();
@@ -158,6 +169,16 @@ export function loadDrawioScript(
 
       script.onload = () => {
         callbacks.onProgress("init");
+
+        // 覆写 draw.io 原型：禁用与 Yjs 实时持久化冲突的 native 对话框
+        const w = window as any;
+        if (w.App?.prototype) {
+          w.App.prototype.onBeforeUnload = function () {}; // 禁止 "All changes will be lost"
+        }
+        if (w.DrawioFile?.prototype) {
+          w.DrawioFile.prototype.addUnsavedStatus = function () {}; // 禁止 "Unsaved changes" 提示
+        }
+
         setTimeout(() => {
           callbacks.onReady(version);
           resolve();

--- a/apps/docs/docs/en/guide/providers.md
+++ b/apps/docs/docs/en/guide/providers.md
@@ -80,6 +80,7 @@ provider.destroy();
 ## Full Example: WebSocket Server with File Persistence
 
 We provide a complete WebSocket server example (`@y-mxgraph/ws-demo`) that includes:
+
 - Custom Node.js server with file system persistence
 - Automatic client synchronization with server data
 - Real-time multi-client collaboration
@@ -143,11 +144,8 @@ The client uses `doc2xml` to load server data into draw.io after `provider.synce
 ```ts
 provider.on('sync', (isSynced) => {
   if (isSynced) {
-    const xml = doc2xml(doc);
-    if (xml) {
-      file.ui.setFileData(xml);
-      file.setData(xml);
-    }
+    // Binding handles file.ui.setFileData(xml) + file.setData(xml) internally
+    // according to the initialContent strategy (default 'replace').
     const binding = new Binding(file, { doc, awareness, undoManager });
   }
 });

--- a/apps/docs/docs/en/guide/sync-strategy.md
+++ b/apps/docs/docs/en/guide/sync-strategy.md
@@ -51,34 +51,41 @@ if (hasData) {
 }
 ```
 
-## Why Manually Sync doc to file
+## How Binding Reconciles doc and file
 
-draw.io's `file.patch()` method only updates internal data structure, **does not trigger UI re-rendering**.
+draw.io's `file.patch()` only updates internal data structure and **does not trigger UI re-rendering**. To repaint the canvas you must call `file.ui.setFileData(xml)`; to keep `file.data` in sync you also need `file.setData(xml)`.
 
-This means:
-- Data is correctly synced to Y.Doc
-- But draw.io UI still shows old data
-
-Therefore, before creating Binding, we need to manually convert Y.Doc data to XML and set it to file:
+Previous versions required callers to do this manually before constructing `Binding`. The current `Binding` handles it automatically via the `initialContent` option (default `replace`):
 
 ```typescript
-import { doc2xml } from 'y-mxgraph';
+// default 'replace': overwrite file UI with doc XML if doc is non-empty
+new Binding(file, { doc });
 
-if (docHasData) {
-  const xml = doc2xml(doc);
-  file.ui.setFileData(xml);  // Update UI display
-  file.setData(xml);         // Update data
-}
+// 'merge-remote': union by diagram id; doc wins on conflicts
+new Binding(file, { doc, initialContent: 'merge-remote' });
+
+// 'merge-client': union by diagram id; file wins on conflicts
+new Binding(file, { doc, initialContent: 'merge-client' });
 ```
 
-This is a limitation of draw.io API. [ws-demo](https://github.com/mizuka-wu/y-mxgraph/tree/main/apps/simple-y-websocket-server-demo) uses the same approach.
+For custom `DrawioFile` subclasses (e.g. `CollabFile` / `DriveFile`) whose `setData` triggers an auto-save, supply the `applyFileData` hook to override the default behaviour:
+
+```typescript
+new Binding(file, {
+  doc,
+  applyFileData: (f, xml) => {
+    // refresh UI only, skip setData to avoid triggering auto-save
+    f.ui.setFileData(xml);
+  },
+});
+```
 
 ## Complete Flow
 
 ```typescript
 import * as Y from 'yjs';
 import { WebrtcProvider } from 'y-webrtc';
-import { Binding, doc2xml } from 'y-mxgraph';
+import { Binding } from 'y-mxgraph';
 
 const doc = new Y.Doc();
 const provider = new WebrtcProvider('my-room', doc);
@@ -93,23 +100,10 @@ function bindDrawio() {
   App.main((ui: any) => {
     const file = ui.currentFile;
 
-    // 1. Check if Y.Doc has data
-    const mxfileMap = doc.getMap('mxfile');
-    const diagramMap = mxfileMap.get('diagram');
-    const docHasData = diagramMap && diagramMap.size > 0;
-
-    // 2. Manually sync data to file
-    if (docHasData) {
-      file.ui.setFileData(doc2xml(doc));
-      file.setData(doc2xml(doc));
-    } else if (!file.data) {
-      file.data = Binding.generateFileTemplate('diagram-0');
-    }
-
-    // 3. Create Binding
+    // Binding internally calls file.ui.setFileData(xml) + file.setData(xml)
+    // according to the initialContent strategy (default 'replace').
     const binding = new Binding(file, { doc });
 
-    // 4. Refresh UI
     ui.refresh();
     window.dispatchEvent(new Event('resize'));
   }, () => {
@@ -141,10 +135,8 @@ if (diagramMap && diagramMap.size > 0) {
 | Feature | demo (WebRTC) | ws-demo (WebSocket) |
 |---------|---------------|---------------------|
 | Sync strategy | Wait for Y.Doc update event | Wait for provider synced event |
-| Data sync | Manual doc2xml + setFileData | Manual doc2xml + setFileData |
+| Data sync | Binding handles automatically (replace) | Binding handles automatically (replace) |
 | Timeout fallback | 500ms | None (WebSocket reliable) |
-
-Both use manual sync approach due to draw.io API limitations.
 
 ## Common Issues
 
@@ -156,9 +148,9 @@ Both use manual sync approach due to draw.io API limitations.
 
 ### Data synced but UI not updated
 
-**Cause**: `file.patch()` doesn't trigger UI re-rendering.
+**Cause**: Neither `file.patch()` nor `file.setData()` repaints the canvas; only `file.ui.setFileData(xml)` rebuilds pages and mxGraphModel.
 
-**Solution**: Manually call `file.ui.setFileData(xml)` and `file.setData(xml)` before creating Binding.
+**Solution**: Use Binding v0.2+ which calls both `setFileData` and `setData` automatically during initialization. If you only need to refresh UI without touching `file.data`, override via the `applyFileData` hook.
 
 ### Orphaned pages appear
 

--- a/apps/docs/docs/guide/getting-started.md
+++ b/apps/docs/docs/guide/getting-started.md
@@ -12,7 +12,7 @@ pnpm add y-mxgraph yjs y-protocols
 
 ```ts
 import * as Y from 'yjs';
-import { Binding, doc2xml } from 'y-mxgraph';
+import { Binding } from 'y-mxgraph';
 
 const doc = new Y.Doc();
 
@@ -20,21 +20,12 @@ const doc = new Y.Doc();
 App.main((app) => {
   const file = app.currentFile;
 
-  // 检查 Y.Doc 是否已有数据（其他客户端同步过来的）
-  const mxfileMap = doc.getMap('mxfile');
-  const diagramMap = mxfileMap.get('diagram');
-  const docHasData = diagramMap && diagramMap.size > 0;
-
-  if (docHasData) {
-    // 优先使用远端数据，确保多端一致
-    file.ui.setFileData(doc2xml(doc));
-    file.setData(doc2xml(doc));
-  } else if (!file.data) {
-    // 本地初始化
-    file.data = Binding.generateFileTemplate('diagram-0');
-  }
-
-  const binding = new Binding(file, { doc });
+  // Binding 会按 `initialContent` 策略（默认 `replace`）自动对齐 file 与 Y.Doc：
+  //   - 'replace'      ：doc 非空时用 doc 内容覆盖 file UI（推荐）
+  //   - 'merge-remote' ：按 diagram id 合并，冲突 id 以 doc 为准
+  //   - 'merge-client' ：按 diagram id 合并，冲突 id 以 file 为准
+  // 内部会调用 `file.ui.setFileData(xml)` + `file.setData(xml)` 触发 UI 重绘。
+  const binding = new Binding(file, { doc /*, initialContent: 'merge-remote' */ });
 });
 ```
 

--- a/apps/docs/docs/guide/providers.md
+++ b/apps/docs/docs/guide/providers.md
@@ -80,6 +80,7 @@ provider.destroy();
 ## 完整示例：WebSocket 服务器 + 文件持久化
 
 我们提供了一个完整的 WebSocket 服务器示例 (`@y-mxgraph/ws-demo`)，包含：
+
 - 自定义 Node.js 服务器，支持文件系统持久化
 - 客户端自动同步服务器数据
 - 支持多客户端实时协作
@@ -138,16 +139,11 @@ setPersistence({
 });
 ```
 
-客户端在 `provider.synced` 后使用 `doc2xml` 将服务器数据加载到 draw.io：
+客户端在 `provider.synced` 后直接创建 Binding，由 Binding 内部按 `initialContent` 策略（默认 `replace`）调用 `file.ui.setFileData(xml)` + `file.setData(xml)` 完成初始化：
 
 ```ts
 provider.on('sync', (isSynced) => {
   if (isSynced) {
-    const xml = doc2xml(doc);
-    if (xml) {
-      file.ui.setFileData(xml);
-      file.setData(xml);
-    }
     const binding = new Binding(file, { doc, awareness, undoManager });
   }
 });

--- a/apps/docs/docs/guide/sync-strategy.md
+++ b/apps/docs/docs/guide/sync-strategy.md
@@ -51,34 +51,41 @@ if (hasData) {
 }
 ```
 
-## 为什么需要手动同步 doc 到 file
+## Binding 如何同步 doc 与 file
 
-draw.io 的 `file.patch()` 方法只更新内部数据结构，**不触发 UI 重新渲染**。
+draw.io 的 `file.patch()` 只更新内部数据结构，**不触发 UI 重新渲染**；UI 重绘需要 `file.ui.setFileData(xml)`，而 `file.data` 则需要 `file.setData(xml)` 才会同步。
 
-这意味着：
-- 数据已正确同步到 Y.Doc
-- 但 draw.io 的 UI 显示的还是旧数据
-
-因此在创建 Binding 前，需要手动把 Y.Doc 数据转成 XML 并设置到 file：
+以前版本需要业务在创建 Binding 前手动同步，现在 **Binding 会自动处理**。通过 `initialContent` 选项控制初始化策略，默认 `replace`：
 
 ```typescript
-import { doc2xml } from 'y-mxgraph';
+// 默认 'replace'：doc 非空时用 doc XML 覆盖 file UI
+new Binding(file, { doc });
 
-if (docHasData) {
-  const xml = doc2xml(doc);
-  file.ui.setFileData(xml);  // 更新 UI 显示
-  file.setData(xml);         // 更新数据
-}
+// 'merge-remote'：按 diagram id 取并集，冲突以 doc 为准
+new Binding(file, { doc, initialContent: 'merge-remote' });
+
+// 'merge-client'：按 diagram id 取并集，冲突以 file 为准
+new Binding(file, { doc, initialContent: 'merge-client' });
 ```
 
-这是 draw.io API 的限制，[ws-demo](https://github.com/mizuka-wu/y-mxgraph/tree/main/apps/simple-y-websocket-server-demo) 也采用相同方案。
+若定制 file 子类（如 CollabFile / DriveFile）在 `setData` 上重写了自动保存逻辑，可以提供 `applyFileData` 钩子接管：
+
+```typescript
+new Binding(file, {
+  doc,
+  applyFileData: (f, xml) => {
+    // 只走 UI 刷新，跳过可能触发保存的 setData
+    f.ui.setFileData(xml);
+  },
+});
+```
 
 ## 完整流程
 
 ```typescript
 import * as Y from 'yjs';
 import { WebrtcProvider } from 'y-webrtc';
-import { Binding, doc2xml } from 'y-mxgraph';
+import { Binding } from 'y-mxgraph';
 
 const doc = new Y.Doc();
 const provider = new WebrtcProvider('my-room', doc);
@@ -93,23 +100,10 @@ function bindDrawio() {
   App.main((ui: any) => {
     const file = ui.currentFile;
 
-    // 1. 检查 Y.Doc 是否有数据
-    const mxfileMap = doc.getMap('mxfile');
-    const diagramMap = mxfileMap.get('diagram');
-    const docHasData = diagramMap && diagramMap.size > 0;
-
-    // 2. 手动同步数据到 file
-    if (docHasData) {
-      file.ui.setFileData(doc2xml(doc));
-      file.setData(doc2xml(doc));
-    } else if (!file.data) {
-      file.data = Binding.generateFileTemplate('diagram-0');
-    }
-
-    // 3. 创建 Binding
+    // Binding 内部会按 initialContent 策略（默认 'replace'）调用
+    // file.ui.setFileData(xml) + file.setData(xml)，业务不需手动处理。
     const binding = new Binding(file, { doc });
 
-    // 4. 刷新 UI
     ui.refresh();
     window.dispatchEvent(new Event('resize'));
   }, () => {
@@ -136,29 +130,13 @@ if (diagramMap && diagramMap.size > 0) {
 }
 ```
 
-## 与 ws-demo 的对比
-
-| 特性 | demo (WebRTC) | ws-demo (WebSocket) |
-|------|---------------|---------------------|
-| 同步策略 | 等待 Y.Doc update 事件 | 等待 provider synced 事件 |
-| 数据同步 | 手动 doc2xml + setFileData | 手动 doc2xml + setFileData |
-| 超时兜底 | 500ms | 无（WebSocket 可靠） |
-
-两者都采用手动同步方案，因为这是 draw.io API 的限制。
-
-## 常见问题
-
-### 新窗口不显示旧窗口的数据
-
-**原因**：Binding 在 Y.Doc 收到远端数据前就创建了。
-
 **解决**：等待 Y.Doc 有数据后再创建 Binding（参考上面的代码）。
 
 ### 数据同步了但 UI 没更新
 
-**原因**：`file.patch()` 不触发 UI 重新渲染。
+**原因**：`file.patch()` / `file.setData()` 都不触发 UI 重绘，只有 `file.ui.setFileData(xml)` 才能重建 pages 与 mxGraphModel。
 
-**解决**：在创建 Binding 前手动调用 `file.ui.setFileData(xml)` 和 `file.setData(xml)`。
+**解决**：使用 v0.2 之后的 Binding，它会自动在初始化阶段同时调用 `setFileData` 与 `setData`；若只需刷 UI 不动 `file.data`，可用 `applyFileData` 钩子覆写默认逻辑。
 
 ### 出现孤立 page
 

--- a/apps/simple-y-websocket-server-demo/src/collaboration.ts
+++ b/apps/simple-y-websocket-server-demo/src/collaboration.ts
@@ -1,7 +1,7 @@
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";
 import { type Awareness } from "y-protocols/awareness";
-import { Binding, LOCAL_ORIGIN, doc2xml } from "y-mxgraph";
+import { Binding, LOCAL_ORIGIN } from "y-mxgraph";
 import { WS_URL, DEFAULT_ROOM } from "./config.js";
 
 export interface CollabState {
@@ -80,32 +80,11 @@ export function bindDrawioFile(
   const tryFinalize = () => {
     if (!appFile || !synced) return;
 
-    const { app, file } = appFile;
-    const mxfileMap = doc.getMap("mxfile");
-    const diagramMap = mxfileMap.get("diagram") as any;
-    const diagramOrder = mxfileMap.get("diagramOrder") as any;
+    const { app: _app, file } = appFile;
+    void _app;
 
-    // 检查是否真的有 diagram 数据
-    const docHasData = diagramMap && diagramMap.size > 0;
-
-    // 先用服务器数据替换本地文件内容,确保页面 ID 一致
-    if (docHasData) {
-      const xml = doc2xml(doc);
-      if (xml && xml.includes("<diagram")) {
-        file.ui.setFileData(xml);
-        file.setData(xml);
-      } else {
-        const template = Binding.generateFileTemplate();
-        file.ui.setFileData(template);
-        file.setData(template);
-      }
-    } else {
-      const template = Binding.generateFileTemplate();
-      file.ui.setFileData(template);
-      file.setData(template);
-    }
-
-    // 再创建 Binding
+    // Binding 默认使用 'replace' 策略，内部会调用
+    // `file.ui.setFileData(doc2xml(doc))` + `file.setData(...)` 完成初始化。
     const binding = new Binding(file, {
       doc,
       awareness,

--- a/packages/y-mxgraph/src/binding/index.ts
+++ b/packages/y-mxgraph/src/binding/index.ts
@@ -1,12 +1,33 @@
 import * as Y from "yjs";
 import { type Awareness } from "y-protocols/awareness";
 import { applyFilePatch, generatePatch, initDocSnapshot } from "./patch";
-import { xml2doc } from "../transformer";
+import { xml2doc, doc2xml } from "../transformer";
 import { bindUndoManager } from "./undoManager";
 import { bindCollaborator } from "./collaborator";
 import { LOCAL_ORIGIN } from "../helper/origin";
-import { key as mxfileKey, type YMxFile } from "../models/mxfile";
+import {
+  key as mxfileKey,
+  diagramOrderKey,
+  type YMxFile,
+} from "../models/mxfile";
+import {
+  key as diagramKey,
+  parse as parseDiagram,
+  type YDiagram,
+} from "../models/diagram";
+import { parse as parseXml } from "../helper/xml";
 import type { DrawioFile, MxGraphModel } from "../types/drawio";
+
+/**
+ * 控制 Binding 构造时 file 与 Y.Doc 的初始内容对齐策略。
+ * - `replace`      : doc 非空则用 doc 覆盖 file；doc 为空则保留 file 现有数据（默认）。
+ * - `merge-remote` : 按 diagram id 取并集，同 id 冲突时以 doc 为准（远端权威）。
+ * - `merge-client` : 按 diagram id 取并集，同 id 冲突时以 file 为准（本地权威，覆盖到 doc）。
+ */
+export type InitialContentStrategy =
+  | "replace"
+  | "merge-remote"
+  | "merge-client";
 
 export interface BindDrawioFileOptions {
   doc: Y.Doc;
@@ -19,6 +40,188 @@ export interface BindDrawioFileOptions {
         userNameKey?: string;
         userColorKey?: string;
       };
+  /**
+   * 初始内容对齐策略，默认 `replace`。详见 {@link InitialContentStrategy}。
+   */
+  initialContent?: InitialContentStrategy;
+  /**
+   * 自定义把 XML 应用到 file 的方式。默认实现只调用
+   * `file.ui.setFileData(xml)`（刷新 UI / 重建 pages），
+   * **不会**调用 `file.setData(xml)`，以避免把 file 标记为「已修改」
+   * 触发 draw.io 的 "Save diagrams to:" 存储选择对话框。
+   *
+   * 若业务方确实需要同步 `file.data`（如自定义 CollabFile 或依赖
+   * `file.save()`），可提供自定义实现。
+   */
+  applyFileData?: (file: DrawioFile, xml: string) => void;
+}
+
+/**
+ * 默认只调用 `file.ui.setFileData(xml)` 重建 UI（pages / mxGraphModel），
+ * 有意跳过 `file.setData(xml)`：在 Yjs 驱动的协作场景下，`file.data`
+ * 不是真实状态来源；调用 `setData` 会把文件标记为「已修改」，
+ * draw.io 在没有配置存储后端时会弹出 "Save diagrams to:" 存储选择对话框。
+ *
+ * 若业务方确实需要同步 `file.data`（例如需要 `file.save()` 或依赖
+ * `file.data` 的快照逻辑），可通过 `applyFileData` 选项覆写：
+ *
+ * ```ts
+ * new Binding(file, {
+ *   doc,
+ *   applyFileData: (f, xml) => {
+ *     f.ui.setFileData(xml);
+ *     f.setData(xml);
+ *   },
+ * });
+ * ```
+ */
+const defaultApplyFileData = (file: DrawioFile, xml: string) => {
+  file.ui.setFileData(xml);
+};
+
+/**
+ * 把 file XML 中的 diagram 合并进 Y.Doc。仅在 merge 策略 + doc 已有数据时调用。
+ * @returns 是否成功合并；解析失败时返回 false 由调用方回退到 replace。
+ */
+function mergeFileIntoDoc(
+  doc: Y.Doc,
+  fileXml: string,
+  strategy: "merge-remote" | "merge-client",
+): boolean {
+  let parsed: unknown;
+  try {
+    parsed = parseXml(fileXml);
+  } catch (err) {
+    console.warn(
+      "[y-mxgraph] 合并失败，file XML 解析异常，回退到 replace：",
+      err,
+    );
+    return false;
+  }
+
+  const mxfileObj = (parsed as Record<string, unknown>)?.mxfile as
+    | { diagram?: Array<Record<string, unknown>> }
+    | undefined;
+  if (!mxfileObj || !Array.isArray(mxfileObj.diagram)) {
+    console.warn(
+      "[y-mxgraph] 合并失败，file XML 不是合法 mxfile，回退到 replace",
+    );
+    return false;
+  }
+
+  const mxfileMap = doc.getMap(mxfileKey);
+  const diagramMap = mxfileMap.get(diagramKey) as Y.Map<YDiagram> | undefined;
+  const diagramOrder = mxfileMap.get(diagramOrderKey) as
+    | Y.Array<string>
+    | undefined;
+  if (!diagramMap || !diagramOrder) {
+    console.warn("[y-mxgraph] 合并失败，doc 结构不完整，回退到 replace");
+    return false;
+  }
+
+  doc.transact(() => {
+    for (const diagram of mxfileObj.diagram!) {
+      const id =
+        ((diagram as { _attributes?: { id?: string } })._attributes
+          ?.id as string) || "";
+      if (!id) continue;
+
+      const docHas = diagramMap.has(id);
+      if (docHas && strategy === "merge-remote") {
+        // doc 优先，跳过
+        continue;
+      }
+
+      // 覆盖或新增
+      const yDiagram = parseDiagram(
+        diagram as unknown as import("../models/diagram").Diagram,
+      );
+      diagramMap.set(id, yDiagram);
+      if (!docHas) {
+        diagramOrder.push([id]);
+      }
+    }
+  });
+  return true;
+}
+
+function reconcileInitialContent(
+  doc: Y.Doc,
+  file: DrawioFile,
+  strategy: InitialContentStrategy,
+  applyFileData: (file: DrawioFile, xml: string) => void,
+): boolean {
+  const mxfileMap = doc.getMap(mxfileKey);
+  const docHasData = mxfileMap.size > 0;
+  // 与旧 demo 行为保持一致：file 是否「有任何数据」用 truthy 判断；
+  // 只有完全空时才注入模板，避免把 draw.io 默认文件覆盖成模板触发
+  // 「Save diagrams to:」存储选择对话框。
+  const fileHasAnyData = !!file.data;
+  // merge 策略需要进一步判断是否存在真实 diagram 内容
+  const fileHasDiagrams = fileHasAnyData && file.data.includes("<diagram");
+
+  if (strategy === "replace") {
+    if (docHasData) {
+      const xml = doc2xml(doc);
+      if (xml && xml.includes("<diagram")) {
+        applyFileData(file, xml);
+      } else if (!fileHasAnyData) {
+        applyFileData(file, Binding.generateFileTemplate("diagram-0"));
+      }
+    } else if (!fileHasAnyData) {
+      applyFileData(file, Binding.generateFileTemplate("diagram-0"));
+    }
+    // 其余情况保留 file，避免触发 draw.io 默认文件的存储对话框
+    return mxfileMap.size > 0;
+  }
+
+  // merge-remote / merge-client
+  if (!docHasData && !fileHasDiagrams) {
+    if (!fileHasAnyData) {
+      applyFileData(file, Binding.generateFileTemplate("diagram-0"));
+    }
+    return false;
+  }
+
+  if (!docHasData && fileHasDiagrams) {
+    // 仅 file 有 → 把 file 写入 doc，file 保持不变
+    try {
+      doc.transact(() => {
+        xml2doc(file.data, doc);
+      });
+      return true;
+    } catch (err) {
+      console.warn(
+        "[y-mxgraph] merge 模式下 xml2doc 失败，回退 replace：",
+        err,
+      );
+      applyFileData(file, Binding.generateFileTemplate("diagram-0"));
+      return false;
+    }
+  }
+
+  if (docHasData && !fileHasDiagrams) {
+    // 仅 doc 有可用 diagram → 用 doc 覆盖 file
+    const xml = doc2xml(doc);
+    if (xml && xml.includes("<diagram")) {
+      applyFileData(file, xml);
+    } else if (!fileHasAnyData) {
+      applyFileData(file, Binding.generateFileTemplate("diagram-0"));
+    }
+    return mxfileMap.size > 0;
+  }
+
+  // 双方都有可用 diagram → 按策略合并
+  const ok = mergeFileIntoDoc(doc, file.data, strategy);
+  if (!ok) {
+    // 解析失败回退到 replace（用 doc 覆盖 file）
+    const xml = doc2xml(doc);
+    if (xml && xml.includes("<diagram")) applyFileData(file, xml);
+    return mxfileMap.size > 0;
+  }
+  const xml = doc2xml(doc);
+  if (xml && xml.includes("<diagram")) applyFileData(file, xml);
+  return true;
 }
 
 /**
@@ -53,7 +256,15 @@ export class Binding {
   private cleanupUndoManager?: () => void;
 
   constructor(file: DrawioFile, options: BindDrawioFileOptions) {
-    const { doc, awareness, undoManager, mouseMoveThrottle, cursor } = options;
+    const {
+      doc,
+      awareness,
+      undoManager,
+      mouseMoveThrottle,
+      cursor,
+      initialContent = "replace",
+      applyFileData = defaultApplyFileData,
+    } = options;
 
     this.doc = doc;
 
@@ -61,32 +272,27 @@ export class Binding {
     const graph = ui.editor.graph;
     this.mxGraphModel = graph.model;
 
-    // 检查 Y.Doc 是否已有数据
-    // 注意：doc.share.has() 可能因 doc.getMap() 调用而为 true 但 map 为空
-    // 因此需要同时检查 map 中是否有实际内容
-    const mxfileMap = doc.getMap(mxfileKey);
-    const docHasData = mxfileMap.size > 0;
-    this.docInitialized = docHasData;
-
-    // 初始化 shadowPages = 当前 pages 的克隆
-    // 这样后续 change 事件如果未真正改变 pages 内容，diffPages 会返回空 patch
-    file.setShadowPages(file.ui.clonePages(file.ui.pages));
-
-    // 若 Y.Doc 已有数据（新客户端加入场景），用 ydoc 内容初始化 file
-    if (docHasData) {
-      initDocSnapshot(doc, false);
-      const fullPatch = generatePatch([], doc);
-      if (Object.keys(fullPatch).length > 0) {
-        this.suppressLocalApply = true;
-        try {
-          file.patch([fullPatch]);
-        } finally {
-          this.suppressLocalApply = false;
-        }
+    // 统一初始化：根据 initialContent 策略对齐 file 与 doc。
+    // 内部会调用 applyFileData 钩子（默认 ui.setFileData + file.setData），
+    // 业务方不再需要在外部手动同步。
+    this.suppressLocalApply = true;
+    try {
+      this.docInitialized = reconcileInitialContent(
+        doc,
+        file,
+        initialContent,
+        applyFileData,
+      );
+      // doc 在 reconcile 后才确定有内容，需建立 snapshot 基线
+      if (this.docInitialized) {
+        initDocSnapshot(doc, false);
       }
-      // 同步后重新对齐 shadowPages
-      file.setShadowPages(file.ui.clonePages(file.ui.pages));
+    } finally {
+      this.suppressLocalApply = false;
     }
+
+    // 对齐 shadowPages（reconcile 可能已经替换了 ui.pages）
+    file.setShadowPages(file.ui.clonePages(file.ui.pages));
 
     // 本地变更监听
     this.mxListener = () => {
@@ -142,7 +348,7 @@ export class Binding {
         this.suppressLocalApply = false;
       }
     };
-    mxfileMap.observeDeep(this.docObserver);
+    doc.getMap(mxfileKey).observeDeep(this.docObserver);
 
     // 协作功能
     if (awareness) {

--- a/packages/y-mxgraph/src/index.ts
+++ b/packages/y-mxgraph/src/index.ts
@@ -1,5 +1,5 @@
 export { Binding } from "./binding";
-export type { BindDrawioFileOptions } from "./binding";
+export type { BindDrawioFileOptions, InitialContentStrategy } from "./binding";
 export { xml2doc, doc2xml } from "./transformer";
 export { LOCAL_ORIGIN } from "./helper/origin";
 export {

--- a/packages/y-mxgraph/src/types/drawio.ts
+++ b/packages/y-mxgraph/src/types/drawio.ts
@@ -64,6 +64,8 @@ export interface DrawioUi {
   pages: unknown[];
   diffPages(oldPages: unknown[], newPages: unknown[]): unknown;
   clonePages(pages: unknown[]): unknown[];
+  /** 解析 XML 并重建 pages / mxGraphModel，触发 UI 重绘 */
+  setFileData(data: string): void;
 }
 
 /** mxGraph 事件对象 */
@@ -81,6 +83,8 @@ export interface DrawioFile {
   getUi(): DrawioUi;
   setShadowPages(pages: unknown[]): void;
   patch(patches: unknown[]): void;
+  /** 仅赋值 this.data = xml，不触发 UI 重绘 */
+  setData(data: string): void;
 }
 
 /** draw.io App（demo 中通过 iframe 访问） */

--- a/packages/y-mxgraph/tests/binding-initial-content.test.ts
+++ b/packages/y-mxgraph/tests/binding-initial-content.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as Y from "yjs";
+import { Binding } from "../src/binding/index";
+import { xml2doc, doc2xml } from "../src/transformer/index";
+import type { DrawioFile } from "../src/types/drawio";
+
+const XML_FILE_ONLY = `<mxfile pages="1">
+  <diagram name="From-File" id="file-1">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>`;
+
+const XML_DOC = `<mxfile pages="1">
+  <diagram name="From-Doc" id="doc-1">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>`;
+
+const XML_BOTH_OVERLAP = `<mxfile pages="2">
+  <diagram name="Shared-File-Side" id="shared">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram name="From-File" id="file-only">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>`;
+
+const XML_DOC_OVERLAP = `<mxfile pages="2">
+  <diagram name="Shared-Doc-Side" id="shared">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram name="From-Doc" id="doc-only">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>`;
+
+function createMockFile(initialData = ""): DrawioFile {
+  const mockGraphModel = {
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    getCell: vi.fn(),
+  };
+  const mockGraph = {
+    model: mockGraphModel,
+    container: {} as HTMLElement,
+    view: { translate: { x: 0, y: 0 }, scale: 1 },
+    addMouseListener: vi.fn(),
+    removeMouseListener: vi.fn(),
+    getSelectionModel: vi.fn(() => ({
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    })),
+    highlightCell: vi.fn(),
+  };
+  const ui = {
+    editor: { graph: mockGraph, undoManager: undefined },
+    currentPage: null,
+    diagramContainer: {} as HTMLElement,
+    pages: [] as unknown[],
+    diffPages: vi.fn(() => ({})),
+    clonePages: vi.fn((p: unknown[]) => [...p]),
+    setFileData: vi.fn(),
+  };
+  const file = {
+    data: initialData,
+    shadowPages: [] as unknown[],
+    ui,
+    getUi() {
+      return ui;
+    },
+    setShadowPages(p: unknown[]) {
+      this.shadowPages = p;
+    },
+    setData: vi.fn(function (this: { data: string }, x: string) {
+      this.data = x;
+    }),
+    patch: vi.fn(),
+  };
+  return file as unknown as DrawioFile;
+}
+
+function getDiagramIds(doc: Y.Doc): string[] {
+  const mxfile = doc.getMap("mxfile");
+  const order = mxfile.get("diagramOrder") as Y.Array<string> | undefined;
+  return order ? order.toArray() : [];
+}
+
+describe("Binding initialContent 策略", () => {
+  describe("replace（默认）", () => {
+    it("doc 有数据 → 用 doc XML 刷新 file UI，默认不调 setData（避开弹框）", () => {
+      const doc = new Y.Doc();
+      xml2doc(XML_DOC, doc);
+      const file = createMockFile(XML_FILE_ONLY);
+
+      new Binding(file, { doc });
+
+      const expected = doc2xml(doc);
+      expect(file.ui.setFileData).toHaveBeenCalledWith(expected);
+      // 默认 applyFileData 不调 setData，避免标记 file 为 modified 触发
+      // draw.io 弹出 "Save diagrams to:" 存储选择对话框。
+      expect(file.setData).not.toHaveBeenCalled();
+      // doc 内容未被 file 改写
+      expect(getDiagramIds(doc)).toEqual(["doc-1"]);
+    });
+
+    it("doc 与 file 都为空 → 写入模板（默认只 setFileData）", () => {
+      const doc = new Y.Doc();
+      const file = createMockFile("");
+
+      new Binding(file, { doc });
+
+      const template = Binding.generateFileTemplate("diagram-0");
+      expect(file.ui.setFileData).toHaveBeenCalledWith(template);
+      expect(file.setData).not.toHaveBeenCalled();
+    });
+
+    it("仅 file 有数据 → 保持 file，不写 doc，不调 setFileData", () => {
+      const doc = new Y.Doc();
+      const file = createMockFile(XML_FILE_ONLY);
+
+      new Binding(file, { doc });
+
+      expect(file.ui.setFileData).not.toHaveBeenCalled();
+      expect(file.setData).not.toHaveBeenCalled();
+      // doc 仍然为空，等首次本地编辑触发 xml2doc
+      expect(doc.getMap("mxfile").size).toBe(0);
+    });
+
+    it("file.data 存在但不含 <diagram>（如 draw.io 默认空文件）→ 不覆盖（避免触发存储对话框）", () => {
+      // 回归：draw.io 默认创建的 file.data 可能是 <mxGraphModel>...</mxGraphModel>
+      // 或 <mxfile></mxfile>，没有 <diagram>。旧版本 demo 在这种情况下不会改写
+      // file.data，Binding 必须保留该行为，否则 setFileData(template) 会触发
+      // draw.io 弹出 "Save diagrams to:" 存储选择对话框。
+      const doc = new Y.Doc();
+      const file = createMockFile("<mxGraphModel><root/></mxGraphModel>");
+
+      new Binding(file, { doc });
+
+      expect(file.ui.setFileData).not.toHaveBeenCalled();
+      expect(file.setData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("merge-remote（doc 优先）", () => {
+    it("双方都有且 id 冲突 → doc 内容保留，file 独有 id 合并", () => {
+      const doc = new Y.Doc();
+      xml2doc(XML_DOC_OVERLAP, doc);
+      const file = createMockFile(XML_BOTH_OVERLAP);
+
+      new Binding(file, { doc, initialContent: "merge-remote" });
+
+      const ids = getDiagramIds(doc);
+      expect(ids).toContain("shared");
+      expect(ids).toContain("doc-only");
+      expect(ids).toContain("file-only");
+
+      // 冲突 id 仍是 doc 的内容（name=Shared-Doc-Side）
+      const diagramMap = doc.getMap("mxfile").get("diagram") as Y.Map<
+        Y.Map<unknown>
+      >;
+      const shared = diagramMap.get("shared") as Y.Map<unknown>;
+      expect(shared.get("name")).toBe("Shared-Doc-Side");
+
+      // setFileData 被调用 + 内容包含全部三个 diagram
+      expect(file.ui.setFileData).toHaveBeenCalled();
+      const writtenXml = (file.ui.setFileData as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as string;
+      expect(writtenXml).toContain('id="shared"');
+      expect(writtenXml).toContain('id="doc-only"');
+      expect(writtenXml).toContain('id="file-only"');
+    });
+
+    it("仅 file 有 → 把 file 写入 doc，file 不动", () => {
+      const doc = new Y.Doc();
+      const file = createMockFile(XML_FILE_ONLY);
+
+      new Binding(file, { doc, initialContent: "merge-remote" });
+
+      expect(getDiagramIds(doc)).toEqual(["file-1"]);
+      // 仅 file 有时不需要再回写 file
+      expect(file.ui.setFileData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("merge-client（file 优先）", () => {
+    it("双方都有且 id 冲突 → file 覆盖 doc 的对应 diagram", () => {
+      const doc = new Y.Doc();
+      xml2doc(XML_DOC_OVERLAP, doc);
+      const file = createMockFile(XML_BOTH_OVERLAP);
+
+      new Binding(file, { doc, initialContent: "merge-client" });
+
+      const diagramMap = doc.getMap("mxfile").get("diagram") as Y.Map<
+        Y.Map<unknown>
+      >;
+      const shared = diagramMap.get("shared") as Y.Map<unknown>;
+      // 冲突 id 现在被 file 覆盖
+      expect(shared.get("name")).toBe("Shared-File-Side");
+
+      const ids = getDiagramIds(doc);
+      expect(ids).toContain("doc-only");
+      expect(ids).toContain("file-only");
+    });
+  });
+
+  describe("applyFileData 自定义钩子", () => {
+    it("自定义钩子被调用，默认 setFileData 不再被触发", () => {
+      const doc = new Y.Doc();
+      xml2doc(XML_DOC, doc);
+      const file = createMockFile(XML_FILE_ONLY);
+      const customApply = vi.fn();
+
+      new Binding(file, { doc, applyFileData: customApply });
+
+      expect(customApply).toHaveBeenCalledTimes(1);
+      const [passedFile, passedXml] = customApply.mock.calls[0];
+      expect(passedFile).toBe(file);
+      expect(passedXml).toBe(doc2xml(doc));
+      // 用户自定义钩子接管后，默认实现不再调用 setFileData
+      expect(file.ui.setFileData).not.toHaveBeenCalled();
+      expect(file.setData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("XML 解析失败回退", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    it("merge-* 模式下 file XML 非法时回退到 replace（用 doc 覆盖）", () => {
+      const doc = new Y.Doc();
+      xml2doc(XML_DOC, doc);
+      const file = createMockFile("<not valid mxfile><diagram></diagram>");
+
+      new Binding(file, { doc, initialContent: "merge-remote" });
+
+      // 回退仍然写回 file（用 doc XML）
+      expect(file.ui.setFileData).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/y-mxgraph/tests/binding.test.ts
+++ b/packages/y-mxgraph/tests/binding.test.ts
@@ -33,7 +33,12 @@ function createMockFile(doc: Y.Doc): DrawioFile {
   };
 
   const mockContainer = {
-    getBoundingClientRect: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
+    getBoundingClientRect: vi.fn(() => ({
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    })),
     scrollLeft: 0,
     scrollTop: 0,
     clientWidth: 800,
@@ -68,12 +73,16 @@ function createMockFile(doc: Y.Doc): DrawioFile {
       pages,
       diffPages: vi.fn(() => ({})),
       clonePages: vi.fn((p: unknown[]) => [...p]),
+      setFileData: vi.fn(),
     },
     getUi: vi.fn(function (this: typeof file) {
       return this.ui;
     }),
     setShadowPages: vi.fn(function (this: typeof file, p: unknown[]) {
       this.shadowPages = p;
+    }),
+    setData: vi.fn(function (this: typeof file, data: string) {
+      this.data = data;
     }),
     patch: vi.fn(),
     _listeners: listeners,


### PR DESCRIPTION
- 在 Binding 构造函数中新增 `initialContent` 选项（默认 `replace`），自动调用 `file.ui.setFileData(xml)` + `file.setData(xml)` 完成 UI 与数据对齐
- 新增 `applyFileData` 钩子允许业务覆写默认同步逻辑（如跳过 `setData` 避免触发自动保存）
- 移除 demo/ws-demo 中手动调用 `doc2xml` + `setFileData` + `setData` 的冗余代码
- 在 drawio-loader 中新