### PR TITLE
fix: protect cell 0/1 from deletion

### DIFF
--- a/packages/y-mxgraph/src/binding/index.ts
+++ b/packages/y-mxgraph/src/binding/index.ts
@@ -1,6 +1,6 @@
 import * as Y from "yjs";
 import { type Awareness } from "y-protocols/awareness";
-import { applyFilePatch, generatePatch, initDocSnapshot } from "./patch";
+import { applyFilePatch, generatePatch, initDocSnapshot, ensureRootCells, syncCellsMapAndOrder, PROTECTED_CELLS, ensureRootCellsInTransaction, CELL_PROTECTION_ORIGIN } from "./patch";
 import { xml2ydoc, ydoc2xml } from "../transform";
 import { bindUndoManager } from "./undoManager";
 import { bindCollaborator } from "./collaborator";
@@ -381,6 +381,7 @@ export class Binding {
       );
       // doc 在 reconcile 后才确定有内容，需建立 snapshot 基线
       if (this.docInitialized) {
+        ensureRootCellsInTransaction(doc);
         initDocSnapshot(doc, false);
       }
     } finally {
@@ -421,6 +422,7 @@ export class Binding {
       }
 
       applyFilePatch(doc, finalPatch, { origin: LOCAL_ORIGIN });
+      ensureRootCellsInTransaction(doc);
       file.setShadowPages(file.ui.clonePages(file.ui.pages));
       this.resetEditorStatus();
     };
@@ -455,6 +457,7 @@ export class Binding {
         try {
           applyFileData(file, xml);
           file.setShadowPages(file.ui.clonePages(file.ui.pages));
+          ensureRootCellsInTransaction(doc);
           initDocSnapshot(doc, false);
           this.docInitialized = true;
 
@@ -545,6 +548,7 @@ export class Binding {
       try {
         this.applyFileData(this.file, xml);
         this.file.setShadowPages(this.file.ui.clonePages(this.file.ui.pages));
+        ensureRootCellsInTransaction(this.doc);
         initDocSnapshot(this.doc, false);
         this.resetEditorStatus();
       } finally {
@@ -553,6 +557,7 @@ export class Binding {
     } else {
       this.doc.transact(() => {
         xml2ydoc(this.file.data, this.doc);
+        ensureRootCells(this.doc);
         initDocSnapshot(this.doc, false);
       }, LOCAL_ORIGIN);
     }
@@ -583,6 +588,8 @@ export class Binding {
       const invalidIds: string[] = [];
 
       for (const cid of ids) {
+        // 跳过受保护的 cell（"0" "1"），即使暂时无效也不删除
+        if (PROTECTED_CELLS.has(cid)) continue;
         const cell = cellsMap.get(cid);
         if (!cell || typeof cell.getAttributes !== "function") {
           invalidIds.push(cid);

--- a/packages/y-mxgraph/src/binding/patch.ts
+++ b/packages/y-mxgraph/src/binding/patch.ts
@@ -28,6 +28,134 @@ const DIFF_INSERT = "i";
 const DIFF_REMOVE = "r";
 const DIFF_UPDATE = "u";
 
+/** 受保护的 cell id：始终存在于 cellsMap 和 cellsOrder 中，不可被删除 */
+export const PROTECTED_CELLS = new Set(["0", "1"]);
+
+/**
+ * 确保 cell 0（根节点）和 cell 1（默认图层）始终存在于 cellsMap 和 cellsOrder 中。
+ * 如果缺失则创建并确保在 cellsOrder 开头（"0" 在最前，"1" 紧随）。
+ */
+export function ensureRootCells(doc: Y.Doc): void {
+  const mxfile = doc.getMap("mxfile");
+  const diagrams = mxfile.get("diagram") as Y.Map<Y.Map<unknown>> | undefined;
+  if (!diagrams) return;
+
+  for (const [, diagram] of diagrams.entries()) {
+    const gm = diagram.get("mxGraphModel") as Y.Map<unknown> | undefined;
+    if (!gm) continue;
+
+    const cellsMap = gm.get("mxCell") as Y.Map<Y.XmlElement> | undefined;
+    const cellsOrder = gm.get("mxCellOrder") as Y.Array<string> | undefined;
+    if (!cellsMap || !cellsOrder) continue;
+
+    // 1. 确保 cellsMap 中存在
+    if (!cellsMap.has("0")) {
+      const cell0 = new Y.XmlElement("mxCell");
+      cell0.setAttribute("id", "0");
+      cellsMap.set("0", cell0);
+    }
+    if (!cellsMap.has("1")) {
+      const cell1 = new Y.XmlElement("mxCell");
+      cell1.setAttribute("id", "1");
+      cell1.setAttribute("parent", "0");
+      cellsMap.set("1", cell1);
+    }
+
+    // 2. 确保 cellsOrder 中存在且位置正确
+    const order = cellsOrder.toArray();
+    const idx0 = order.indexOf("0");
+    const idx1 = order.indexOf("1");
+
+    // 如果 0 不在 order 中，插入到最前面
+    if (idx0 === -1) {
+      cellsOrder.insert(0, ["0"]);
+    }
+    // 如果 1 不在 order 中，插入到 0 后面
+    if (idx1 === -1) {
+      const currentIdx0 = cellsOrder.toArray().indexOf("0");
+      cellsOrder.insert(currentIdx0 >= 0 ? currentIdx0 + 1 : 0, ["1"]);
+    }
+
+    // 3. 确保顺序：0 必须在 1 前面
+    const finalOrder = cellsOrder.toArray();
+    const finalIdx0 = finalOrder.indexOf("0");
+    const finalIdx1 = finalOrder.indexOf("1");
+    if (finalIdx0 !== -1 && finalIdx1 !== -1 && finalIdx0 > finalIdx1) {
+      // 0 在 1 后面，需要调整：删除 1，插入到 0 后面
+      cellsOrder.delete(finalIdx1, 1);
+      const newIdx0 = cellsOrder.toArray().indexOf("0");
+      cellsOrder.insert(newIdx0 >= 0 ? newIdx0 + 1 : 0, ["1"]);
+    }
+
+    // 防止 CRDT 并发导致的重复条目
+    ensureUniqueOrder(cellsOrder);
+  }
+}
+
+/**
+ * 同步 cellsMap 和 cellsOrder：清理 order 中的孤儿 id，补回 map 中缺失的 id。
+ * 跳过受保护的 cell（"0" "1"）。
+ */
+export function syncCellsMapAndOrder(doc: Y.Doc): void {
+  const mxfile = doc.getMap("mxfile");
+  const diagrams = mxfile.get("diagram") as Y.Map<Y.Map<unknown>> | undefined;
+  if (!diagrams) return;
+
+  for (const [, diagram] of diagrams.entries()) {
+    const gm = diagram.get("mxGraphModel") as Y.Map<unknown> | undefined;
+    if (!gm) continue;
+
+    const cellsMap = gm.get("mxCell") as Y.Map<Y.XmlElement> | undefined;
+    const cellsOrder = gm.get("mxCellOrder") as Y.Array<string> | undefined;
+    if (!cellsMap || !cellsOrder) continue;
+
+    const mapKeys = new Set(cellsMap.keys());
+    const currentOrder = cellsOrder.toArray();
+
+    // 移除 order 中不存在于 map 的 id（跳过受保护 cell）
+    const toRemove = currentOrder.filter(
+      (id) => !mapKeys.has(id) && !PROTECTED_CELLS.has(id),
+    );
+    if (toRemove.length > 0) {
+      for (const id of toRemove) {
+        const idx = cellsOrder.toArray().indexOf(id);
+        if (idx !== -1) cellsOrder.delete(idx, 1);
+      }
+    }
+
+    // 补回 map 中存在但 order 中缺失的 id（受保护 cell 放前面）
+    const orderSet = new Set(cellsOrder.toArray());
+    const toAdd = [...mapKeys].filter((id) => !orderSet.has(id));
+    if (toAdd.length > 0) {
+      const protectedToAdd = toAdd.filter((id) => PROTECTED_CELLS.has(id));
+      const normalToAdd = toAdd.filter((id) => !PROTECTED_CELLS.has(id));
+      // 受保护 cell 放最前面
+      if (protectedToAdd.length > 0) {
+        cellsOrder.insert(0, protectedToAdd);
+      }
+      // 普通 cell 放最后面
+      if (normalToAdd.length > 0) {
+        cellsOrder.push(normalToAdd);
+      }
+    }
+
+    // 防止 CRDT 并发导致的重复条目
+    ensureUniqueOrder(cellsOrder);
+  }
+}
+
+/**
+ * 在 transaction 内执行 ensureRootCells + syncCellsMapAndOrder。
+ * 使用 CELL_PROTECTION_ORIGIN 避免污染用户 undo 栈。
+ */
+export const CELL_PROTECTION_ORIGIN = "cell-protection";
+export function ensureRootCellsInTransaction(doc: Y.Doc): void {
+  doc.transact(() => {
+    ensureRootCells(doc);
+    syncCellsMapAndOrder(doc);
+  }, CELL_PROTECTION_ORIGIN);
+}
+
 type DocSnapshot = {
   diagramOrder: string[] | null;
   cellsOrder: Map<string, string[]>;
@@ -613,18 +741,21 @@ export function applyFilePatch(
             }
 
             // 删除单元格 - 按照 draw.io 原始实现，在最后处理
-            if (update.cells[DIFF_REMOVE] && update.cells[DIFF_REMOVE].length) {
+            const cellsToRemove = update.cells[DIFF_REMOVE]?.filter(
+              (cid: string) => !PROTECTED_CELLS.has(cid),
+            );
+            if (cellsToRemove && cellsToRemove.length) {
               if (orderArr) {
                 const orderIds = orderArr.toArray();
-                const removeIndexList = update.cells[DIFF_REMOVE].map((cid) =>
+                const removeIndexList = cellsToRemove.map((cid: string) =>
                   orderIds.indexOf(cid),
                 )
                   .filter((i) => i !== -1)
                   .sort((a, b) => b - a);
-                removeIndexList.forEach((idx) => orderArr.delete(idx, 1));
+                removeIndexList.forEach((idx: number) => orderArr.delete(idx, 1));
               }
               if (cellsMap) {
-                update.cells[DIFF_REMOVE].forEach((cid) => {
+                cellsToRemove.forEach((cid: string) => {
                   if (cellsMap.has(cid)) {
                     cellsMap.delete(cid);
                   }
@@ -699,6 +830,11 @@ export function initDocSnapshot(doc: Y.Doc, resetSnapshot = false) {
 
         if (cellsMap) {
           for (const cid of ids) {
+            // 跳过受保护的 cell（"0" "1"），即使暂时无效也不清理
+            if (PROTECTED_CELLS.has(cid)) {
+              validIds.push(cid);
+              continue;
+            }
             const el = cellsMap.get(cid) as Y.XmlElement | undefined;
             if (el && typeof el.getAttributes === "function") {
               validIds.push(cid);
@@ -897,7 +1033,9 @@ export function generatePatch(
     const prevSet = new Set(prevCells);
     const currSet = new Set(currCells);
 
-    const removed = prevCells.filter((cid: string) => !currSet.has(cid) && cid);
+    const removed = prevCells.filter(
+      (cid: string) => !currSet.has(cid) && cid && !PROTECTED_CELLS.has(cid),
+    );
     if (removed.length) {
       const cells = ensureCellSection(did);
       cells[DIFF_REMOVE] = (cells[DIFF_REMOVE] || []).concat(removed);

--- a/packages/y-mxgraph/src/models/mxGraphModel.ts
+++ b/packages/y-mxgraph/src/models/mxGraphModel.ts
@@ -24,7 +24,8 @@ export interface MxGraphModel extends ElementCompact {
 export type YMxGraphModel = Y.Map<unknown>;
 
 export function parse(object: MxGraphModel, doc?: Y.Doc) {
-  const mxCells = (object.root[mxCellKey] || []).map((cell: MxCellModel) => {
+  const mxCellsRaw = object.root[mxCellKey] || [];
+  const mxCells = (Array.isArray(mxCellsRaw) ? mxCellsRaw : [mxCellsRaw]).map((cell: MxCellModel) => {
     return {
       value: parseMxCell(cell),
       id: (cell._attributes?.id || "") as string,
@@ -40,7 +41,25 @@ export function parse(object: MxGraphModel, doc?: Y.Doc) {
     cells.set(cell.id, cell.value);
   });
 
-  cellsOrder.push(mxCells.map((cell) => cell.id));
+  const ids = mxCells.map((cell) => cell.id);
+  cellsOrder.push(ids);
+
+  // 确保 cell 0（根节点）和 cell 1（默认图层）始终存在
+  // 注意：standalone Y.Map 的 has() 不可靠，用 ids 数组检查
+  if (!ids.includes("0")) {
+    const cell0 = new Y.XmlElement("mxCell");
+    cell0.setAttribute("id", "0");
+    cells.set("0", cell0);
+    cellsOrder.insert(0, ["0"]);
+  }
+  if (!ids.includes("1")) {
+    const cell1 = new Y.XmlElement("mxCell");
+    cell1.setAttribute("id", "1");
+    cell1.setAttribute("parent", "0");
+    cells.set("1", cell1);
+    const idx0 = cellsOrder.toArray().indexOf("0");
+    cellsOrder.insert(idx0 >= 0 ? idx0 + 1 : 0, ["1"]);
+  }
 
   mxGraphElement.set(mxCellKey, cells);
   mxGraphElement.set(mxCellOrderKey, cellsOrder);
@@ -143,10 +162,36 @@ export function serialize(map: YMxGraphModel) {
       `[y-mxgraph] serialize: cellsOrder contains invalid Y.XmlElement: ${invalidIds.join(",")}`,
     );
   }
+  // 确保输出中始终包含 cell 0 和 cell 1
+  const hasCell0 = ordered.some(
+    (c) => (c as Y.XmlElement).getAttribute("id") === "0",
+  );
+  const hasCell1 = ordered.some(
+    (c) => (c as Y.XmlElement).getAttribute("id") === "1",
+  );
+
+  // 序列化所有正常 cell
+  const serialized = ordered.map((cell) => serializeMxCell(cell));
+
+  // 补入缺失的 protected cell（直接构造序列化对象，不创建 Y.XmlElement）
+  if (!hasCell0) {
+    serialized.unshift({ _attributes: { id: "0" }, mxCell: [] });
+  }
+  if (!hasCell1) {
+    const idx0 = serialized.findIndex(
+      (c) => (c as any)?._attributes?.id === "0",
+    );
+    const insertIdx = idx0 >= 0 ? idx0 + 1 : 0;
+    serialized.splice(insertIdx, 0, {
+      _attributes: { id: "1", parent: "0" },
+      mxCell: [],
+    });
+  }
+
   return {
     _attributes,
     root: {
-      [mxCellKey]: ordered.map((cell) => serializeMxCell(cell)),
+      [mxCellKey]: serialized,
     },
   };
 }

--- a/packages/y-mxgraph/tests/cell-protection.test.ts
+++ b/packages/y-mxgraph/tests/cell-protection.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest";
+import * as Y from "yjs";
+import { xml2ydoc, ydoc2xml } from "../src/transform/index";
+import {
+  applyFilePatch,
+  generatePatch,
+  initDocSnapshot,
+  ensureRootCells,
+  syncCellsMapAndOrder,
+  PROTECTED_CELLS,
+} from "../src/binding/patch";
+
+const BASE_XML = `<mxfile pages="1"><diagram name="Page-1" id="p1"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`;
+
+function makeDoc(xml = BASE_XML) {
+  const doc = new Y.Doc();
+  xml2ydoc(xml, doc);
+  initDocSnapshot(doc);
+  return doc;
+}
+
+function getCells(doc: Y.Doc) {
+  const mxfile = doc.getMap("mxfile");
+  const diags = mxfile.get("diagram") as Y.Map<any>;
+  const gm = (diags.get("p1") as Y.Map<any>).get("mxGraphModel") as Y.Map<any>;
+  return {
+    cellsMap: gm.get("mxCell") as Y.Map<Y.XmlElement>,
+    cellsOrder: gm.get("mxCellOrder") as Y.Array<string>,
+  };
+}
+
+// ─── PROTECTED_CELLS 常量 ───
+
+describe("PROTECTED_CELLS", () => {
+  it("包含 0 和 1", () => {
+    expect(PROTECTED_CELLS.has("0")).toBe(true);
+    expect(PROTECTED_CELLS.has("1")).toBe(true);
+  });
+});
+
+// ─── ensureRootCells ───
+
+describe("ensureRootCells", () => {
+  it("正常 doc 不做任何修改", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    const orderBefore = cellsOrder.toArray();
+    ensureRootCells(doc);
+    expect(cellsMap.has("0")).toBe(true);
+    expect(cellsMap.has("1")).toBe(true);
+    expect(cellsOrder.toArray()).toEqual(orderBefore);
+  });
+
+  it("cellsMap 缺少 cell 0 时恢复", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    cellsMap.delete("0");
+    expect(cellsMap.has("0")).toBe(false);
+
+    ensureRootCells(doc);
+
+    expect(cellsMap.has("0")).toBe(true);
+    const cell0 = cellsMap.get("0")!;
+    expect(cell0.getAttribute("id")).toBe("0");
+    // cell 0 应在 cellsOrder 最前面
+    expect(cellsOrder.toArray()[0]).toBe("0");
+  });
+
+  it("cellsMap 缺少 cell 1 时恢复", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    cellsMap.delete("1");
+    expect(cellsMap.has("1")).toBe(false);
+
+    ensureRootCells(doc);
+
+    expect(cellsMap.has("1")).toBe(true);
+    const cell1 = cellsMap.get("1")!;
+    expect(cell1.getAttribute("id")).toBe("1");
+    expect(cell1.getAttribute("parent")).toBe("0");
+    // cell 1 应紧跟 cell 0
+    const order = cellsOrder.toArray();
+    expect(order.indexOf("0")).toBeLessThan(order.indexOf("1"));
+  });
+
+  it("cellsMap 缺少 cell 0 和 1 时同时恢复", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    cellsMap.delete("0");
+    cellsMap.delete("1");
+
+    ensureRootCells(doc);
+
+    expect(cellsMap.has("0")).toBe(true);
+    expect(cellsMap.has("1")).toBe(true);
+    const order = cellsOrder.toArray();
+    expect(order[0]).toBe("0");
+    expect(order[1]).toBe("1");
+  });
+
+  it("cellsOrder 缺少 cell 0/1 但 cellsMap 有，补回 order", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    // 从 order 中移除 0 和 1，但保留 cellsMap
+    const order = cellsOrder.toArray();
+    cellsOrder.delete(0, order.length);
+    cellsOrder.push(order.filter((id) => id !== "0" && id !== "1"));
+
+    ensureRootCells(doc);
+
+    const newOrder = cellsOrder.toArray();
+    expect(newOrder[0]).toBe("0");
+    expect(newOrder[1]).toBe("1");
+  });
+});
+
+// ─── syncCellsMapAndOrder ───
+
+describe("syncCellsMapAndOrder", () => {
+  it("清理 order 中不在 cellsMap 的孤儿 id", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    // 添加一个孤儿 id 到 order
+    cellsOrder.push(["orphan1", "orphan2"]);
+
+    syncCellsMapAndOrder(doc);
+
+    const order = cellsOrder.toArray();
+    expect(order).not.toContain("orphan1");
+    expect(order).not.toContain("orphan2");
+  });
+
+  it("不会删除受保护的孤儿 id（0/1）", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    // 即使 0/1 不在 cellsMap 中（理论上不该发生），也不从 order 删除
+    cellsMap.delete("0");
+    cellsMap.delete("1");
+    // 重新添加到 order 但不加到 map
+    cellsOrder.insert(0, ["0", "1"]);
+
+    syncCellsMapAndOrder(doc);
+
+    const order = cellsOrder.toArray();
+    expect(order).toContain("0");
+    expect(order).toContain("1");
+  });
+
+  it("补回 map 中存在但 order 中缺失的 id", () => {
+    const doc = makeDoc();
+    const { cellsMap, cellsOrder } = getCells(doc);
+    // 添加一个 cell 到 map 但不加到 order
+    const cell = new Y.XmlElement("mxCell");
+    cell.setAttribute("id", "extra");
+    cellsMap.set("extra", cell);
+
+    syncCellsMapAndOrder(doc);
+
+    expect(cellsOrder.toArray()).toContain("extra");
+  });
+});
+
+// ─── applyFilePatch 保护 ───
+
+describe("applyFilePatch — cell 0/1 保护", () => {
+  it("删除 cell 0 被阻止", () => {
+    const doc = makeDoc();
+    const { cellsMap } = getCells(doc);
+    expect(cellsMap.has("0")).toBe(true);
+
+    applyFilePatch(doc, {
+      u: { p1: { cells: { r: ["0"] } } },
+    });
+
+    // cell 0 仍然存在
+    expect(cellsMap.has("0")).toBe(true);
+  });
+
+  it("删除 cell 1 被阻止", () => {
+    const doc = makeDoc();
+    const { cellsMap } = getCells(doc);
+    expect(cellsMap.has("1")).toBe(true);
+
+    applyFilePatch(doc, {
+      u: { p1: { cells: { r: ["1"] } } },
+    });
+
+    expect(cellsMap.has("1")).toBe(true);
+  });
+
+  it("同时删除 cell 0 和 cell 1 都被阻止", () => {
+    const doc = makeDoc();
+    const { cellsMap } = getCells(doc);
+
+    applyFilePatch(doc, {
+      u: { p1: { cells: { r: ["0", "1"] } } },
+    });
+
+    expect(cellsMap.has("0")).toBe(true);
+    expect(cellsMap.has("1")).toBe(true);
+  });
+
+  it("删除普通 cell 不受影响", () => {
+    const XML_WITH_CELL = `<mxfile pages="1"><diagram name="Page-1" id="p1"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/><mxCell id="c1" parent="1" vertex="1"/></root></mxGraphModel></diagram></mxfile>`;
+    const doc = makeDoc(XML_WITH_CELL);
+    const { cellsMap } = getCells(doc);
+    expect(cellsMap.has("c1")).toBe(true);
+
+    applyFilePatch(doc, {
+      u: { p1: { cells: { r: ["c1"] } } },
+    });
+
+    expect(cellsMap.has("c1")).toBe(false);
+  });
+
+  it("删除混合列表：只删除普通 cell，保留 0/1", () => {
+    const XML_WITH_CELLS = `<mxfile pages="1"><diagram name="Page-1" id="p1"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/><mxCell id="c1" parent="1" vertex="1"/><mxCell id="c2" parent="1" vertex="1"/></root></mxGraphModel></diagram></mxfile>`;
+    const doc = makeDoc(XML_WITH_CELLS);
+    const { cellsMap } = getCells(doc);
+
+    applyFilePatch(doc, {
+      u: { p1: { cells: { r: ["0", "1", "c1", "c2"] } } },
+    });
+
+    expect(cellsMap.has("0")).toBe(true);
+    expect(cellsMap.has("1")).toBe(true);
+    expect(cellsMap.has("c1")).toBe(false);
+    expect(cellsMap.has("c2")).toBe(false);
+  });
+});
+
+// ─── generatePatch 保护 ───
+
+describe("generatePatch — cell 0/1 保护", () => {
+  it("不产生 cell 0/1 的删除 patch", () => {
+    const doc = makeDoc();
+    initDocSnapshot(doc);
+
+    // 从 cellsMap 中移除 cell 0 和 1（模拟损坏）
+    const { cellsMap, cellsOrder } = getCells(doc);
+    cellsMap.delete("0");
+    cellsMap.delete("1");
+    // 从 order 中也移除
+    const order = cellsOrder.toArray();
+    cellsOrder.delete(0, order.length);
+    cellsOrder.push(order.filter((id) => id !== "0" && id !== "1"));
+
+    const patch = generatePatch([]);
+
+    // patch 中不应包含 0/1 的删除操作
+    if (patch.u?.p1?.cells?.r) {
+      expect(patch.u.p1.cells.r).not.toContain("0");
+      expect(patch.u.p1.cells.r).not.toContain("1");
+    }
+  });
+});
+
+// ─── parse 保护 ───
+
+describe("mxGraphModel.parse — cell 0/1 保护", () => {
+  it("XML 缺少 cell 0 时自动创建", () => {
+    const xml = `<mxfile pages="1"><diagram name="Page-1" id="p1"><mxGraphModel><root><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`;
+    const doc = new Y.Doc();
+    xml2ydoc(xml, doc);
+
+    const { cellsMap } = getCells(doc);
+    expect(cellsMap.has("0")).toBe(true);
+    expect(cellsMap.get("0")!.getAttribute("id")).toBe("0");
+  });
+
+  it("XML 缺少 cell 1 时自动创建", () => {
+    const xml = `<mxfile pages="1"><diagram name="Page-1" id="p1"><mxGraphModel><root><mxCell id="0"/></root></mxGraphModel></diagram></mxfile>`;
+    const doc = new Y.Doc();
+    xml2ydoc(xml, doc);
+
+    const { cellsMap } = getCells(doc);
+    expect(cellsMap.has("1")).toBe(true);
+    const cell1 = cellsMap.get("1")!;
+    expect(cell1.getAttribute("id")).toBe("1");
+    expect(cell1.getAttribute("parent")).toBe("0");
+  });
+
+  it("XML 缺少 cell 0 和 1 时同时创建", () => {
+    const xml = `<mxfile pages="1"><diagram name="Page-1" id="p1"><mxGraphModel><root><mxCell id="2" parent="1" vertex="1"/></root></mxGraphModel></diagram></mxfile>`;
+    const doc = new Y.Doc();
+    xml2ydoc(xml, doc);
+
+    const { cellsMap } = getCells(doc);
+    expect(cellsMap.has("0")).toBe(true);
+    expect(cellsMap.has("1")).toBe(true);
+  });
+});
+
+// ─── serialize 保护 ───
+
+describe("mxGraphModel.serialize — cell 0/1 保护", () => {
+  it("输出始终包含 cell 0 和 1", () => {
+    const doc = makeDoc();
+    // ydoc2xml already imported at top
+    const xml = ydoc2xml(doc);
+    expect(xml).toContain('id="0"');
+    expect(xml).toContain('id="1"');
+  });
+
+  it("cellsMap 缺少 0/1 时 serialize 输出仍包含", () => {
+    const doc = makeDoc();
+    const { cellsMap } = getCells(doc);
+    cellsMap.delete("0");
+    cellsMap.delete("1");
+
+    // ydoc2xml already imported at top
+    const xml = ydoc2xml(doc);
+    expect(xml).toContain('id="0"');
+    expect(xml).toContain('id="1"');
+  });
+});


### PR DESCRIPTION
## 概述

修复 cell 0（根节点）和 cell 1（默认图层）可能被意外删除的问题。

## 改动

### patch.ts
- 新增 `PROTECTED_CELLS` 常量，标记不可删除的 cell
- 新增 `ensureRootCells(doc)` — 如果 cell 0/1 缺失则自动创建并插入到 cellsOrder 开头
- 新增 `syncCellsMapAndOrder(doc)` — 清理 order 中的孤儿 id，补回 map 中缺失的 id（跳过受保护 cell）
- `applyFilePatch` 删除逻辑：过滤掉受保护 cell，拒绝删除 "0" "1"
- `generatePatch` 删除检测：排除受保护 cell，不产生删除 patch

### mxGraphModel.ts
- `parse()`：解析 XML 后检查 cellsMap/cellsOrder，若缺失 "0" 或 "1" 则自动创建并插入
- `serialize()`：输出前检查，若 ordered 中缺失 "0" 或 "1" 则补入

### index.ts
- 导入 `ensureRootCells`/`syncCellsMapAndOrder`
- Binding 构造函数：reconcile 后、initDocSnapshot 前调用
- 本地变更监听：applyFilePatch 后调用
- 远端变更监听：applyFileData 后调用
- forceSync：两个方向都调用

## 测试
所有 61 个测试通过（含 cell-protection.test.ts）。

Closes #18