### PR TITLE
fix: protect cell 0/1 from deletion + recovery mechanism

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -112,6 +112,15 @@
       cursor: not-allowed;
     }
 
+    .tool-btn.danger {
+      background: #fff5f5;
+      color: #c92a2a;
+    }
+
+    .tool-btn.danger:hover {
+      background: #ffc9c9;
+    }
+
     /* ── 对比结果面板 ── */
     #compare-panel {
       position: fixed;
@@ -420,6 +429,13 @@
       <button class="tool-btn" id="btn-export-xml" title="下载当前 Y.Doc 序列化后的 XML">导出 Y.Doc XML</button>
       <button class="tool-btn" id="btn-compare-xml" title="上传 XML 并与当前 Y.Doc 对比统计信息">上传 XML 对比</button>
       <input type="file" id="xml-upload-input" accept=".xml" style="display:none" />
+    </div>
+
+    <div class="separator"></div>
+
+    <div class="toolbar-group">
+      <button class="tool-btn danger" id="btn-delete-cells" title="从 Y.Doc 中删除 cell 0 和 cell 1，触发自动恢复">模拟删除 Cell 0/1</button>
+      <button class="tool-btn" id="btn-reset-ydoc" title="从 file.data 强制重建 ydoc（止损失效时的手动恢复）">从 file 重建 ydoc</button>
     </div>
   </div>
 

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -426,4 +426,74 @@ xmlUploadInput.addEventListener("change", (e) => {
 comparePanelClose.addEventListener("click", hideComparePanel);
 comparePanelOverlay.addEventListener("click", hideComparePanel);
 
+// === 模拟删除 Cell 0/1 ===
+const btnDeleteCells = document.getElementById(
+  "btn-delete-cells",
+) as HTMLButtonElement;
+
+btnDeleteCells.addEventListener("click", () => {
+  const doc = getCurrentDoc();
+  if (!doc) {
+    alert("Y.Doc 尚未初始化，请等待 draw.io 加载完成");
+    return;
+  }
+
+  const mxfile = doc.getMap("mxfile");
+  const diagrams = mxfile.get("diagram") as Y.Map<Y.Map<unknown>> | undefined;
+  if (!diagrams) {
+    alert("Y.Doc 中没有 diagram");
+    return;
+  }
+
+  let deletedCount = 0;
+  for (const [, diagram] of diagrams.entries()) {
+    const gm = diagram.get("mxGraphModel") as Y.Map<unknown> | undefined;
+    if (!gm) continue;
+    const cellsMap = gm.get("mxCell") as Y.Map<Y.XmlElement> | undefined;
+    const cellsOrder = gm.get("mxCellOrder") as Y.Array<string> | undefined;
+    if (!cellsMap || !cellsOrder) continue;
+
+    for (const id of ["0", "1"]) {
+      if (cellsMap.has(id)) {
+        cellsMap.delete(id);
+        deletedCount++;
+      }
+      const order = cellsOrder.toArray();
+      const idx = order.indexOf(id);
+      if (idx !== -1) {
+        cellsOrder.delete(idx, 1);
+        deletedCount++;
+      }
+    }
+  }
+
+  if (deletedCount === 0) {
+    alert("Cell 0/1 已经不存在了");
+    return;
+  }
+
+  console.warn(`[y-mxgraph] 已删除 ${deletedCount} 个 cell 0/1 条目，图表将损坏`);
+  alert(`已删除 cell 0/1（${deletedCount} 条）\n\n恢复方式：\n• 远端协作者同步时自动恢复\n• 刷新页面时 initBinding 自动恢复\n• 点击「从 file 重建 ydoc」手动恢复`);
+});
+
+// === 从 file 重建 ydoc ===
+const btnResetYdoc = document.getElementById(
+  "btn-reset-ydoc",
+) as HTMLButtonElement;
+
+btnResetYdoc.addEventListener("click", () => {
+  const binding = collabState.binding;
+  if (!binding) {
+    alert("Binding 尚未初始化，请等待 draw.io 加载完成");
+    return;
+  }
+
+  try {
+    (binding as any).resetYdocFromFile();
+    alert("✓ ydoc 已从 file.data 重建");
+  } catch (e) {
+    alert("重建失败: " + (e as Error).message);
+  }
+});
+
 window.addEventListener("DOMContentLoaded", init);

--- a/apps/docs/docs/en/guide/architecture.md
+++ b/apps/docs/docs/en/guide/architecture.md
@@ -332,6 +332,78 @@ function ensureUniqueOrder(orderArr: Y.Array<string>) {
 }
 ```
 
+## Error Recovery
+
+### Cell 0/1 Protection
+
+Cell 0 (root node) and Cell 1 (default layer) are fundamental to draw.io's structure. If they are deleted from the Y.Doc, the entire diagram breaks. y-mxgraph provides multi-layer protection:
+
+| Defense Point | Mechanism | Scenario Covered |
+|---------------|-----------|-----------------|
+| `applyFilePatch` | Filters deletion list, skips `"0"` `"1"` | Accidental deletion in file→ydoc path |
+| `generatePatch` | Filters diff detection, won't mark `"0"` `"1"` as deleted | False positive in diff detection |
+| `docObserver` | Calls `ensureBasicCell()` after remote/undo-redo changes | Remote peer deletion |
+| `cleanInvalidCellOrder` | Skips `"0"` `"1"` during forceSync cleanup | Cleanup logic false positive |
+| `mxGraphModel.parse` | Fallback creation of cell 0/1 during XML parsing | Missing from XML |
+
+### `ensureBasicCell` Function
+
+```ts
+export function ensureBasicCell(doc: Y.Doc): void {
+  // Iterates all diagrams, ensures "0" and "1" exist in cellsMap and cellsOrder
+  // Creates them if missing and inserts at the beginning of cellsOrder
+  // Ensures 0 comes before 1
+}
+```
+
+**Idempotent**: If cell 0/1 already exist, no operation is performed. Safe to call at any time.
+
+### When It Runs
+
+1. **`initBinding`**: Immediately restores missing cells when loading an existing ydoc (fixes historical data)
+2. **`docObserver`**: Ensures cell 0/1 exist after remote sync or undo/redo changes
+3. **`mxGraphModel.parse`**: Fallback creation during XML→ydoc conversion
+
+### Protected Cells
+
+```ts
+export const PROTECTED_CELLS = new Set(["0", "1"]);
+```
+
+All deletion logic (`applyFilePatch`, `generatePatch`, `cleanInvalidCellOrder`) checks this set and skips protected cells.
+
+### Snapshot Recovery
+
+When the ydoc is corrupted (missing cell 0/1), recovering from a historical snapshot follows this flow:
+
+```
+snapshot (has cell 0/1) → reset file.data → initDocSnapshot rebuilds baseline → diff → patch
+```
+
+**Problem before the fix**: `generatePatch` would detect missing cell 0/1 as "removed", generating a deletion patch. Even though cell 0/1 already didn't exist, this detection would affect subsequent diff logic, causing recovery to fail.
+
+**After the fix**:
+- `generatePatch` filters `"0"` `"1"`, won't mark them as deleted
+- `applyFilePatch` filters `"0"` `"1"`, won't execute deletion
+- `ensureBasicCell` restores missing cells in `initBinding` and `docObserver`
+
+Therefore, the snapshot recovery path is safe: regardless of the ydoc's current state, as long as the snapshot is correct, recovery will succeed.
+
+### Manual Recovery: `resetYdocFromFile()`
+
+When automatic recovery fails (e.g., ydoc severely corrupted, remote sync unavailable), call `binding.resetYdocFromFile()` to force-rebuild the ydoc from file.data:
+
+```ts
+binding.resetYdocFromFile();
+```
+
+**Flow**: `file.data` (XML) → `xml2ydoc` → `mxGraphModel.parse` (fallback creates cell 0/1) → `ensureBasicCell` → ydoc complete
+
+**Difference from `forceSync("file-to-ydoc")`**:
+- `forceSync` is routine sync: cleans invalid cellOrder, resets drift counter
+- `resetYdocFromFile` is destructive recovery: discards all ydoc data, rebuilds from file XML
+- Use when ydoc is severely corrupted and other recovery methods have failed
+
 ## Performance
 
 1. **Batched patch apply**: multiple changes in a single transaction

--- a/apps/docs/docs/guide/architecture.md
+++ b/apps/docs/docs/guide/architecture.md
@@ -339,6 +339,78 @@ function ensureUniqueOrder(orderArr: Y.Array<string>) {
 }
 ```
 
+## 错误恢复机制
+
+### Cell 0/1 保护
+
+Cell 0（根节点）和 Cell 1（默认图层）是 draw.io 的基础结构。如果它们从 Y.Doc 中被删除，整个图表会崩溃。y-mxgraph 在多个层级提供保护：
+
+| 防御点 | 机制 | 覆盖场景 |
+|--------|------|----------|
+| `applyFilePatch` | 过滤删除列表，跳过 `"0"` `"1"` | file→ydoc 路径误删 |
+| `generatePatch` | 过滤差异检测，不将 `"0"` `"1"` 标记为删除 | diff 检测误判 |
+| `docObserver` | 远端/undo-redo 变更后调用 `ensureBasicCell()` | 远端 peer 删除 |
+| `cleanInvalidCellOrder` | forceSync 清理时跳过 `"0"` `"1"` | 清理逻辑误删 |
+| `mxGraphModel.parse` | XML 解析兜底创建 cell 0/1 | XML 缺失 |
+
+### `ensureBasicCell` 函数
+
+```ts
+export function ensureBasicCell(doc: Y.Doc): void {
+  // 遍历所有 diagram，确保 cellsMap 和 cellsOrder 中存在 "0" 和 "1"
+  // 如果缺失则创建并插入到 cellsOrder 开头
+  // 确保 0 在 1 前面
+}
+```
+
+**幂等**：如果 cell 0/1 已存在，不做任何操作。可在任何时机安全调用。
+
+### 调用时机
+
+1. **`initBinding`**：加载已有 ydoc 时立即补（修复历史缺失）
+2. **`docObserver`**：远端同步或 undo/redo 后确保 cell 0/1 存在
+3. **`mxGraphModel.parse`**：XML→ydoc 转换时兜底创建
+
+### 受保护的 Cell
+
+```ts
+export const PROTECTED_CELLS = new Set(["0", "1"]);
+```
+
+所有删除逻辑（`applyFilePatch`、`generatePatch`、`cleanInvalidCellOrder`）都会检查此集合，跳过受保护的 cell。
+
+### 从 Snapshot 恢复
+
+当 ydoc 已损坏（缺少 cell 0/1）时，从历史 snapshot 恢复的流程：
+
+```
+snapshot（有 cell 0/1）→ 重设 file.data → initDocSnapshot 重建 baseline → diff → patch
+```
+
+**修复前的问题**：`generatePatch` 会将缺失的 cell 0/1 检测为「删除」，生成删除 patch。即使 cell 0/1 已经不存在，这个检测结果仍然会影响后续的 diff 逻辑，导致恢复失败。
+
+**修复后**：
+- `generatePatch` 过滤 `"0"` `"1"`，不会将它们标记为删除
+- `applyFilePatch` 过滤 `"0"` `"1"`，不会执行删除
+- `ensureBasicCell` 在 `initBinding` 和 `docObserver` 中补回缺失的 cell
+
+因此从 snapshot 恢复的路径是安全的：无论 ydoc 当前状态如何，只要 snapshot 是好的，就能正确恢复。
+
+### 手动恢复：`resetYdocFromFile()`
+
+当自动恢复手段失效时（如 ydoc 严重损坏、远端同步无法触发），可调用 `binding.resetYdocFromFile()` 强制从 file.data 重建 ydoc：
+
+```ts
+binding.resetYdocFromFile();
+```
+
+**流程**：`file.data` (XML) → `xml2ydoc` → `mxGraphModel.parse`（兜底创建 cell 0/1）→ `ensureBasicCell` → ydoc 完整
+
+**与 `forceSync("file-to-ydoc")` 的区别**：
+- `forceSync` 是常规同步，会清理异常 cellOrder、重置 drift 计数
+- `resetYdocFromFile` 是破坏性恢复：丢弃当前 ydoc 全部数据，从 file XML 重建
+- 适用于 ydoc 严重损坏且其他恢复手段失效的场景
+
 ## 性能优化
 
 1. **patch 批量应用**: 单次事务包含多个变更

--- a/packages/y-mxgraph/src/binding/index.ts
+++ b/packages/y-mxgraph/src/binding/index.ts
@@ -1,6 +1,6 @@
 import * as Y from "yjs";
 import { type Awareness } from "y-protocols/awareness";
-import { applyFilePatch, generatePatch, initDocSnapshot } from "./patch";
+import { applyFilePatch, generatePatch, initDocSnapshot, ensureBasicCell, PROTECTED_CELLS } from "./patch";
 import { xml2ydoc, ydoc2xml } from "../transform";
 import { bindUndoManager } from "./undoManager";
 import { bindCollaborator } from "./collaborator";
@@ -381,6 +381,7 @@ export class Binding {
       );
       // doc 在 reconcile 后才确定有内容，需建立 snapshot 基线
       if (this.docInitialized) {
+        ensureBasicCell(doc);
         initDocSnapshot(doc, false);
       }
     } finally {
@@ -443,6 +444,9 @@ export class Binding {
       if (transaction.local && !isUndoRedo) {
         return;
       }
+
+      // 远端/undo-redo 变更后，确保 cell 0/1 存在
+      ensureBasicCell(doc);
 
       const xml = ydoc2xml(doc);
       if (xml && xml.includes("<diagram")) {
@@ -563,6 +567,45 @@ export class Binding {
   }
 
   /**
+   * 从 file.data 强制重建 ydoc（止损失效时的手动恢复手段）。
+   *
+   * 与 forceSync("file-to-ydoc") 的区别：
+   * - forceSync 是常规同步，会清理异常 cellOrder、重置 drift 计数
+   * - resetYdocFromFile 是破坏性恢复：丢弃当前 ydoc 全部数据，从 file XML 重建
+   * - 适用于 ydoc 严重损坏（如缺少 cell 0/1）且其他恢复手段失效的场景
+   *
+   * 流程：file.data (XML) → xml2ydoc → mxGraphModel.parse（兜底创建 cell 0/1）→ ydoc 完整
+   */
+  resetYdocFromFile(): void {
+    const xml = this.file.data;
+    if (!xml || !xml.includes("<diagram")) {
+      console.warn("[y-mxgraph] resetYdocFromFile: file.data 为空或无 diagram");
+      return;
+    }
+
+    this.suppressLocalApply = true;
+    try {
+      this.doc.transact(() => {
+        xml2ydoc(xml, this.doc);
+        ensureBasicCell(this.doc);
+        initDocSnapshot(this.doc, true);
+      }, LOCAL_ORIGIN);
+
+      // 用重建后的 ydoc 覆盖 file（确保两端一致）
+      const rebuiltXml = ydoc2xml(this.doc);
+      if (rebuiltXml && rebuiltXml.includes("<diagram")) {
+        this.applyFileData(this.file, rebuiltXml);
+        this.file.setShadowPages(this.file.ui.clonePages(this.file.ui.pages));
+      }
+
+      this.resetEditorStatus();
+      console.log("[y-mxgraph] resetYdocFromFile: ydoc 已从 file.data 重建");
+    } finally {
+      this.suppressLocalApply = false;
+    }
+  }
+
+  /**
    * 清理 cellsMap 中不存在的 cell id，避免影响 undo 栈。
    * 只在 forceSync 时调用，因为这是用户主动触发的同步操作。
    */
@@ -583,6 +626,7 @@ export class Binding {
       const invalidIds: string[] = [];
 
       for (const cid of ids) {
+        if (PROTECTED_CELLS.has(cid)) continue;
         const cell = cellsMap.get(cid);
         if (!cell || typeof cell.getAttributes !== "function") {
           invalidIds.push(cid);

--- a/packages/y-mxgraph/src/binding/patch.ts
+++ b/packages/y-mxgraph/src/binding/patch.ts
@@ -28,6 +28,52 @@ const DIFF_INSERT = "i";
 const DIFF_REMOVE = "r";
 const DIFF_UPDATE = "u";
 
+/** 受保护的 cell id：始终存在，不可被删除 */
+export const PROTECTED_CELLS = new Set(["0", "1"]);
+
+/**
+ * 确保指定 diagram 的 cellsMap 和 cellsOrder 中存在 cell 0 和 cell 1。
+ * 如果缺失则创建并插入到 cellsOrder 开头。
+ */
+export function ensureBasicCell(doc: Y.Doc): void {
+  const mxfile = doc.getMap("mxfile");
+  const diagrams = mxfile.get("diagram") as Y.Map<Y.Map<unknown>> | undefined;
+  if (!diagrams) return;
+  for (const [, diagram] of diagrams.entries()) {
+    const gm = diagram.get("mxGraphModel") as Y.Map<unknown> | undefined;
+    if (!gm) continue;
+    const cellsMap = gm.get("mxCell") as Y.Map<Y.XmlElement> | undefined;
+    const cellsOrder = gm.get("mxCellOrder") as Y.Array<string> | undefined;
+    if (!cellsMap || !cellsOrder) continue;
+
+    let order = cellsOrder.toArray();
+    if (!cellsMap.has("0")) {
+      const c = new Y.XmlElement("mxCell");
+      c.setAttribute("id", "0");
+      cellsMap.set("0", c);
+      if (!order.includes("0")) cellsOrder.insert(0, ["0"]);
+      order = cellsOrder.toArray();
+    }
+    if (!cellsMap.has("1")) {
+      const c = new Y.XmlElement("mxCell");
+      c.setAttribute("id", "1");
+      c.setAttribute("parent", "0");
+      cellsMap.set("1", c);
+      const idx0 = cellsOrder.toArray().indexOf("0");
+      cellsOrder.insert(idx0 >= 0 ? idx0 + 1 : 0, ["1"]);
+      order = cellsOrder.toArray();
+    }
+    // 确保 0 在 1 前面
+    const i0 = order.indexOf("0");
+    const i1 = order.indexOf("1");
+    if (i0 !== -1 && i1 !== -1 && i0 > i1) {
+      cellsOrder.delete(i1, 1);
+      const newI0 = cellsOrder.toArray().indexOf("0");
+      cellsOrder.insert(newI0 >= 0 ? newI0 + 1 : 0, ["1"]);
+    }
+  }
+}
+
 type DocSnapshot = {
   diagramOrder: string[] | null;
   cellsOrder: Map<string, string[]>;
@@ -613,18 +659,22 @@ export function applyFilePatch(
             }
 
             // 删除单元格 - 按照 draw.io 原始实现，在最后处理
-            if (update.cells[DIFF_REMOVE] && update.cells[DIFF_REMOVE].length) {
+            // 跳过受保护 cell（"0" "1"）
+            const cellsToRemove = update.cells[DIFF_REMOVE]?.filter(
+              (cid: string) => !PROTECTED_CELLS.has(cid),
+            );
+            if (cellsToRemove && cellsToRemove.length) {
               if (orderArr) {
                 const orderIds = orderArr.toArray();
-                const removeIndexList = update.cells[DIFF_REMOVE].map((cid) =>
+                const removeIndexList = cellsToRemove.map((cid: string) =>
                   orderIds.indexOf(cid),
                 )
                   .filter((i) => i !== -1)
                   .sort((a, b) => b - a);
-                removeIndexList.forEach((idx) => orderArr.delete(idx, 1));
+                removeIndexList.forEach((idx: number) => orderArr.delete(idx, 1));
               }
               if (cellsMap) {
-                update.cells[DIFF_REMOVE].forEach((cid) => {
+                cellsToRemove.forEach((cid: string) => {
                   if (cellsMap.has(cid)) {
                     cellsMap.delete(cid);
                   }
@@ -897,7 +947,9 @@ export function generatePatch(
     const prevSet = new Set(prevCells);
     const currSet = new Set(currCells);
 
-    const removed = prevCells.filter((cid: string) => !currSet.has(cid) && cid);
+    const removed = prevCells.filter(
+      (cid: string) => !currSet.has(cid) && cid && !PROTECTED_CELLS.has(cid),
+    );
     if (removed.length) {
       const cells = ensureCellSection(did);
       cells[DIFF_REMOVE] = (cells[DIFF_REMOVE] || []).concat(removed);

--- a/packages/y-mxgraph/src/models/mxGraphModel.ts
+++ b/packages/y-mxgraph/src/models/mxGraphModel.ts
@@ -42,6 +42,22 @@ export function parse(object: MxGraphModel, doc?: Y.Doc) {
 
   cellsOrder.push(mxCells.map((cell) => cell.id));
 
+  // 兜底：确保 cell 0（根节点）和 cell 1（默认图层）存在
+  if (!cells.has("0")) {
+    const c = new Y.XmlElement("mxCell");
+    c.setAttribute("id", "0");
+    cells.set("0", c);
+    cellsOrder.insert(0, ["0"]);
+  }
+  if (!cells.has("1")) {
+    const c = new Y.XmlElement("mxCell");
+    c.setAttribute("id", "1");
+    c.setAttribute("parent", "0");
+    cells.set("1", c);
+    const i0 = cellsOrder.toArray().indexOf("0");
+    cellsOrder.insert(i0 >= 0 ? i0 + 1 : 0, ["1"]);
+  }
+
   mxGraphElement.set(mxCellKey, cells);
   mxGraphElement.set(mxCellOrderKey, cellsOrder);
 


### PR DESCRIPTION
Core:
- applyFilePatch: filter out '0' '1' from deletion list
- generatePatch: filter out '0' '1' from removal detection
- docObserver: ensureBasicCell() after remote/undo-redo changes
- cleanInvalidCellOrder: skip protected cells
- mxGraphModel.parse: fallback create cell 0/1 if missing
- initBinding: ensureBasicCell for existing ydocs with missing cells
- Binding.resetYdocFromFile(): manual recovery from file.data XML

Demo:
- Simulate cell deletion button (red, toolbar)
- Rebuild ydoc from file button (toolbar)

Docs (zh + en):
- Error recovery mechanism section
- Cell 0/1 protection, ensureBasicCell, snapshot recovery
- resetYdocFromFile() manual recovery